### PR TITLE
SEO: Fix title/meta for 'websites in 7 days' + homepage + config keywords

### DIFF
--- a/src/config/config.toml
+++ b/src/config/config.toml
@@ -1,7 +1,7 @@
 # Site Configuration
 [site]
   title             = "WordPress Web Designer in Skipton & Keighley | BVS Web Design" # Shared title for SEO and OpenGraph
-  description       = "Website design and development in Wordpress, Wix and Squarespace - Website design for Small to Medium sized businesses based between Skipton and Keighley." # Shared description for SEO and OpenGraph
+  description       = "WordPress web design in Skipton & Keighley. Fast, affordable websites for small businesses. Free website audit. Serving Yorkshire and the UK." # Shared description for SEO and OpenGraph
   tagline           = "Website Design and Development for growing businesses"
   taglineSeparator = " - " # default is " - " 
   baseUrl          = "https://www.bvswebdesign.co.uk" # Base URL for the site and used in OpenGraph meta tags.
@@ -27,16 +27,16 @@
 [seo]
   author   = "Steve Marks"
   keywords = [
-    "digital agency", 
-    "website development",
-    "website design",
-    "web development",
-    "web design",
+    "web design skipton",
+    "web designer skipton",
+    "website design skipton",
+    "web design keighley",
+    "web designer keighley",
+    "wordpress web design yorkshire",
     "wordpress websites",
-    "website maintenance",
-    "website designer in skipton",
-    "website designer in yorkshire",
-    "help with my website"
+    "website design yorkshire",
+    "small business web design",
+    "websites in 7 days"
   ]
   robots   = "index, follow" # Instructs search engines on how to crawl and index the pages.
 

--- a/src/content/homepage/english/-index.md
+++ b/src/content/homepage/english/-index.md
@@ -1,6 +1,6 @@
 ---
 title: ""
-metaDescription: "Website design and development in Wordpress, Wix and Squarespace - Based between Skipton and Keighley, I work on websites for small to medium businesses across the UK"
+metaDescription: "Web design in Skipton & Keighley. Professional WordPress websites for local businesses — built fast, priced fairly, with ongoing support. Get a free website audit today."
 includeLocalBusiness: true
 
 # Override Default Content of `/sections/services-section.md`

--- a/src/content/services/english/service-05.mdx
+++ b/src/content/services/english/service-05.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Websites in a Week – Fast, Affordable & Professional"
+title: "Websites in 7 Days | Fast, Affordable WordPress Websites"
 customSlug: websites-in-a-week
 image: "/images/services/website-design.jpg"
 date: 2025-05-10
@@ -13,7 +13,7 @@ tags:
   - "Small Business"
   - "Affordable Web Design"
 draft: false
-metaDescription: "Need a professional website fast? Get a fully designed WordPress site delivered in just one week. Affordable packages for small businesses from BVS Web Design."
+metaDescription: "Get a professional WordPress website in just 7 days. Fast, affordable packages for small businesses across the UK — delivered in a week by BVS Web Design in Skipton."
 ---
 
 import TestimonialArticle from "@/components/sections/TestimonialArticle.astro"


### PR DESCRIPTION
## What & Why

GSC data shows two high-value opportunities with zero clicks:

| Query | Position | Impressions | CTR |
|---|---|---|---|
| websites in 7 days uk | 1.7 | 140 | 0% |
| websites in 7 days | 3.1 | 121 | 0% |

We're ranking position 1–3 but nobody is clicking because the page title says **'Websites in a Week'** while users are searching **'7 days'**. Title mismatch kills CTR even at top positions.

## Changes

### `service-05.mdx` (Websites in a Week page)
- **Title:** `Websites in a Week – Fast, Affordable & Professional` → `Websites in 7 Days | Fast, Affordable WordPress Websites`
- **Meta description:** Rewritten to lead with '7 days', adds location (Skipton)

### `homepage/english/-index.md`
- **Meta description:** Rewritten to lead with Skipton & Keighley, removes Wix/Squarespace references, adds CTA hook

### `config.toml`
- **Site description:** Tightened to local keywords
- **Keywords:** Replaced generic terms (digital agency, help with my website) with actual ranking targets (web design skipton, websites in 7 days, etc.)

## Expected Impact
- Immediate CTR improvement on 'websites in 7 days' queries (261 impressions/90 days at pos 1-3)
- Incremental improvement on Skipton local terms (homepage pos 9–10)